### PR TITLE
Add dot plot script for upregulated pathways

### DIFF
--- a/pathway_dotplot.R
+++ b/pathway_dotplot.R
@@ -1,0 +1,101 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages({
+  library(ggplot2)
+  library(dplyr)
+})
+
+# Embedded data for the upregulated pathways and their p-values
+pathway_df <- tibble::tibble(
+  Pathway = c(
+    "Signaling by Non-Receptor Tyrosine Kinases",
+    "Tryptophan catabolism",
+    "Alanine and aspartate metabolism",
+    "Metabolism of amino acids and derivatives",
+    "Selenoamino acid metabolism",
+    "Glycerolipids and glycerophospholipids",
+    "Glycerophospholipid biosynthesis",
+    "Phosphatidylethanolamine Biosynthesis",
+    "Phospholipid metabolism",
+    "Phosphatidylcholine Biosynthesis",
+    "Transport of nucleotide sugars",
+    "Biomarkers for pyrimidine metabolism disorders",
+    "Pyrimidine catabolism",
+    "Nucleotide catabolism",
+    "Pyrimidine metabolism and related diseases",
+    "Apparent mineralocorticoid excess syndrome",
+    "Defective SLC35A2 causes congenital disorder of glycosylation 2M (CDG2M)",
+    "Keratan sulfate biosynthesis",
+    "PTK6 Expression",
+    "Kennedy pathway from sphingolipids",
+    "Synthesis of ceramides and 1-deoxyceramides",
+    "Sphingolipid pathway",
+    "Sphingolipid metabolism",
+    "Sphingolipid metabolism overview",
+    "Steroidogenesis",
+    "11-beta-hydroxylase deficiency (CYP11B1)",
+    "17-alpha-hydroxylase deficiency (CYP17)",
+    "21-hydroxylase deficiency (CYP21)",
+    "3-Beta-Hydroxysteroid Dehydrogenase Deficiency"
+  ),
+  p_value = c(
+    0.000661,
+    0.00293,
+    0.00633,
+    0.0139,
+    0.0343,
+    0.00157,
+    0.0085,
+    0.00876,
+    0.0123,
+    0.0137,
+    3.21e-05,
+    0.00404,
+    0.00541,
+    0.0118,
+    0.044,
+    3.02e-06,
+    6.05e-06,
+    7.11e-06,
+    2.39e-05,
+    0.000416,
+    0.000729,
+    0.000862,
+    0.00104,
+    0.00137,
+    3.02e-06,
+    3.02e-06,
+    3.02e-06,
+    3.02e-06,
+    3.02e-06
+  )
+) %>%
+  arrange(p_value)
+
+# Determine dynamic x-axis limit consistent with the Python script
+x_max <- -log10(min(pathway_df$p_value)) + 1
+
+plot <- ggplot(pathway_df, aes(x = -log10(p_value), y = reorder(Pathway, p_value))) +
+  geom_point(color = "red", size = 2) +
+  labs(
+    x = "-log10(p-value)",
+    y = "Pathway",
+    title = "Upregulated Pathway Enrichment"
+  ) +
+  coord_cartesian(xlim = c(0, x_max)) +
+  theme_minimal(base_size = 12) +
+  theme(
+    panel.grid.major.y = element_blank(),
+    panel.grid.minor = element_blank()
+  )
+
+print(plot)
+
+ggsave(
+  filename = "upregulated_pathway_dotplot.svg",
+  plot = plot,
+  width = 9,
+  height = 10,
+  dpi = 300,
+  units = "in"
+)

--- a/pathway_dotplot.R
+++ b/pathway_dotplot.R
@@ -1,5 +1,19 @@
 #!/usr/bin/env Rscript
 
+required_packages <- c("ggplot2", "dplyr", "svglite")
+missing_packages <- required_packages[!
+  vapply(
+    required_packages,
+    requireNamespace,
+    FUN.VALUE = logical(1),
+    quietly = TRUE
+  )
+]
+
+if (length(missing_packages) > 0) {
+  install.packages(missing_packages, repos = "https://cloud.r-project.org")
+}
+
 suppressPackageStartupMessages({
   library(ggplot2)
   library(dplyr)

--- a/pathway_dotplot.R
+++ b/pathway_dotplot.R
@@ -100,7 +100,12 @@ plot <- ggplot(pathway_df, aes(x = -log10(p_value), y = reorder(Pathway, p_value
   theme_minimal(base_size = 12) +
   theme(
     panel.grid.major.y = element_blank(),
-    panel.grid.minor = element_blank()
+    panel.grid.minor = element_blank(),
+    axis.ticks.y = element_line(color = "black"),
+    axis.ticks.x = element_line(color = "black"),
+    axis.ticks.length = grid::unit(3, "pt"),
+    axis.line.y = element_line(color = "black"),
+    axis.line.x = element_line(color = "black")
   )
 
 print(plot)

--- a/pathway_dotplot.py
+++ b/pathway_dotplot.py
@@ -1,0 +1,108 @@
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+# Embedded data for upregulated pathways and their p-values
+DATA = {
+    "Pathway": [
+        "Signaling by Non-Receptor Tyrosine Kinases",
+        "Tryptophan catabolism",
+        "Alanine and aspartate metabolism",
+        "Metabolism of amino acids and derivatives",
+        "Selenoamino acid metabolism",
+        "Glycerolipids and glycerophospholipids",
+        "Glycerophospholipid biosynthesis",
+        "Phosphatidylethanolamine Biosynthesis",
+        "Phospholipid metabolism",
+        "Phosphatidylcholine Biosynthesis",
+        "Transport of nucleotide sugars",
+        "Biomarkers for pyrimidine metabolism disorders",
+        "Pyrimidine catabolism",
+        "Nucleotide catabolism",
+        "Pyrimidine metabolism and related diseases",
+        "Apparent mineralocorticoid excess syndrome",
+        "Defective SLC35A2 causes congenital disorder of glycosylation 2M (CDG2M)",
+        "Keratan sulfate biosynthesis",
+        "PTK6 Expression",
+        "Kennedy pathway from sphingolipids",
+        "Synthesis of ceramides and 1-deoxyceramides",
+        "Sphingolipid pathway",
+        "Sphingolipid metabolism",
+        "Sphingolipid metabolism overview",
+        "Steroidogenesis",
+        "11-beta-hydroxylase deficiency (CYP11B1)",
+        "17-alpha-hydroxylase deficiency (CYP17)",
+        "21-hydroxylase deficiency (CYP21)",
+        "3-Beta-Hydroxysteroid Dehydrogenase Deficiency",
+    ],
+    "p-value": [
+        6.61e-4,
+        2.93e-3,
+        6.33e-3,
+        1.39e-2,
+        3.43e-2,
+        1.57e-3,
+        8.50e-3,
+        8.76e-3,
+        1.23e-2,
+        1.37e-2,
+        3.21e-5,
+        4.04e-3,
+        5.41e-3,
+        1.18e-2,
+        4.40e-2,
+        3.02e-6,
+        6.05e-6,
+        7.11e-6,
+        2.39e-5,
+        4.16e-4,
+        7.29e-4,
+        8.62e-4,
+        1.04e-3,
+        1.37e-3,
+        3.02e-6,
+        3.02e-6,
+        3.02e-6,
+        3.02e-6,
+        3.02e-6,
+    ],
+}
+
+
+def plot_enriched_categories(df: pd.DataFrame, title: str, filename: str) -> None:
+    """Plot a dot plot for the supplied pathway enrichment results."""
+    df_sorted = df.sort_values(by="p-value", ascending=True)
+
+    plt.figure(figsize=(9, 10), dpi=300)
+    sns.scatterplot(
+        y=df_sorted["Pathway"],
+        x=-np.log10(df_sorted["p-value"]),
+        color="red",
+        edgecolor="red",
+        s=30,
+    )
+    plt.xlabel("-log10(p-value)", fontsize=12)
+    plt.ylabel("Pathway", fontsize=12)
+    plt.title(title, fontsize=14)
+    plt.xticks(fontsize=10)
+    plt.yticks(fontsize=9)
+    max_xlim = -np.log10(df_sorted["p-value"].min()) + 1
+    plt.xlim(0, max_xlim)
+    plt.grid(axis="x", linestyle="--", linewidth=0.5)
+    plt.tight_layout()
+    plt.savefig(filename, format="svg")
+    plt.show()
+
+
+def main() -> None:
+    df_pathways = pd.DataFrame(DATA).dropna(subset=["p-value"])
+    plot_enriched_categories(
+        df_pathways,
+        "Upregulated Pathway Enrichment",
+        "upregulated_pathway_dotplot.svg",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pathway_dotplot.py
+++ b/pathway_dotplot.py
@@ -87,6 +87,8 @@ def plot_enriched_categories(df: pd.DataFrame, title: str, filename: str) -> Non
     plt.title(title, fontsize=14)
     plt.xticks(fontsize=10)
     plt.yticks(fontsize=9)
+    plt.tick_params(axis="y", which="both", length=4, width=0.8)
+    plt.tick_params(axis="x", which="both", length=4, width=0.8)
     max_xlim = -np.log10(df_sorted["p-value"].min()) + 1
     plt.xlim(0, max_xlim)
     plt.grid(axis="x", linestyle="--", linewidth=0.5)


### PR DESCRIPTION
## Summary
- add a standalone plotting script for the provided upregulated pathways and p-values
- keep the dot plot styling from the previous workflow while sorting by significance and exporting SVG output

## Testing
- python -m compileall pathway_dotplot.py
- python pathway_dotplot.py *(fails: missing numpy/matplotlib/seaborn in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b65590248323985b5152a07723a1